### PR TITLE
Bump fedora-bootc submodule

### DIFF
--- a/.github/workflows/bump-fedora-bootc.yaml
+++ b/.github/workflows/bump-fedora-bootc.yaml
@@ -12,21 +12,22 @@ jobs:
   bump-fedora-bootc-submodule:
     name: Bump fedora-bootc submodule
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/coreos-assembler/coreos-assembler:latest
-      options: "--user root --privileged"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       # https://github.com/actions/checkout/issues/766
       - name: Mark git checkout as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check if there are new commits
         run: |
+          set -x
           previous_rev=$(git -C fedora-bootc rev-parse HEAD)
           git submodule update --remote fedora-bootc
+          # the submodule init only fetch the submodule commit
+          # git -C fedora-bootc fetch origin master
           new_rev=$(git -C fedora-bootc rev-parse HEAD)
           if [ "${previous_rev}" != "${new_rev}" ]; then
               if git -C fedora-bootc diff --quiet "${previous_rev}" "${new_rev}" tier-0 tier-x; then
@@ -39,7 +40,9 @@ jobs:
               exit 0
           fi
 
-          git -C fedora-bootc shortlog --no-merges "${previous_rev}..${new_rev}" > $RUNNER_TEMP/shortlog
+          git status
+          git -C fedora-bootc shortlog "${previous_rev}..${new_rev}" -- tier-0 tier-x
+          git -C fedora-bootc shortlog "${previous_rev}..${new_rev}" -- tier-0 tier-x > $RUNNER_TEMP/shortlog
 
           marker=END-OF-LOG-MARKER-$RANDOM$RANDOM$RANDOM
           cat >> $GITHUB_ENV <<EOF
@@ -51,7 +54,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
-          push-to-fork: coreosbot-releng/fedora-coreos-config
+          push-to-fork: jlebon/fedora-coreos-config
           branch: bump-fedora-bootc
           commit-message: |
             Bump fedora-bootc submodule


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/jlebon/fedora-coreos-config/actions/workflows/bump-fedora-bootc.yml) ([source](https://github.com/jlebon/fedora-coreos-config/blob/testing-devel/.github/workflows/bump-fedora-bootc.yml)).

```
Jonathan Lebon (5):
      tier-0: explicitly list coreutils
      tier-x: explicitly list podman, skopeo
      tier-0: drop `mkdir -p /run` workaround
      tier-0: fix sed invocation
      Merge branch 'pr/coreutils' into 'main'
```