### PR TITLE
Bump fedora-bootc submodule

### DIFF
--- a/.github/workflows/bump-fedora-bootc.yaml
+++ b/.github/workflows/bump-fedora-bootc.yaml
@@ -12,19 +12,18 @@ jobs:
   bump-fedora-bootc-submodule:
     name: Bump fedora-bootc submodule
     runs-on: ubuntu-latest
-    container:
-      image: quay.io/coreos-assembler/coreos-assembler:latest
-      options: "--user root --privileged"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
       # https://github.com/actions/checkout/issues/766
       - name: Mark git checkout as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Check if there are new commits
         run: |
+          set -x
           previous_rev=$(git -C fedora-bootc rev-parse HEAD)
           git submodule update --remote fedora-bootc
           new_rev=$(git -C fedora-bootc rev-parse HEAD)
@@ -39,7 +38,9 @@ jobs:
               exit 0
           fi
 
-          git -C fedora-bootc shortlog --no-merges "${previous_rev}..${new_rev}" > $RUNNER_TEMP/shortlog
+          git status
+          git -C fedora-bootc shortlog --no-merges "${previous_rev}..${new_rev}" -- tier-0 tier-x
+          git -C fedora-bootc shortlog --no-merges "${previous_rev}..${new_rev}" -- tier-0 tier-x > $RUNNER_TEMP/shortlog
 
           marker=END-OF-LOG-MARKER-$RANDOM$RANDOM$RANDOM
           cat >> $GITHUB_ENV <<EOF
@@ -51,7 +52,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
-          push-to-fork: coreosbot-releng/fedora-coreos-config
+          push-to-fork: jlebon/fedora-coreos-config
           branch: bump-fedora-bootc
           commit-message: |
             Bump fedora-bootc submodule

--- a/.github/workflows/bump-fedora-bootc.yaml
+++ b/.github/workflows/bump-fedora-bootc.yaml
@@ -1,0 +1,68 @@
+name: Bump fedora-bootc submodule
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump-fedora-bootc-submodule:
+    name: Bump fedora-bootc submodule
+    runs-on: ubuntu-latest
+    container:
+      image: quay.io/coreos-assembler/coreos-assembler:latest
+      options: "--user root --privileged"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+      # https://github.com/actions/checkout/issues/766
+      - name: Mark git checkout as safe
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Check if there are new commits
+        run: |
+          previous_rev=$(git -C fedora-bootc rev-parse HEAD)
+          git submodule update --remote fedora-bootc
+          new_rev=$(git -C fedora-bootc rev-parse HEAD)
+          if [ "${previous_rev}" != "${new_rev}" ]; then
+              if git -C fedora-bootc diff --quiet "${previous_rev}" "${new_rev}" tier-0 tier-x; then
+                  # reset back any changes to avoid a PR bump
+                  git submodule update
+              fi
+          fi
+          if git diff --quiet --exit-code; then
+              echo "No tier-0 or tier-x changes; exiting"
+              exit 0
+          fi
+
+          git -C fedora-bootc shortlog --no-merges "${previous_rev}..${new_rev}" > $RUNNER_TEMP/shortlog
+
+          marker=END-OF-LOG-MARKER-$RANDOM$RANDOM$RANDOM
+          cat >> $GITHUB_ENV <<EOF
+          SHORTLOG<<$marker
+          $(cat $RUNNER_TEMP/shortlog)
+          $marker
+          EOF
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.COREOSBOT_RELENG_TOKEN }}
+          push-to-fork: coreosbot-releng/fedora-coreos-config
+          branch: bump-fedora-bootc
+          commit-message: |
+            Bump fedora-bootc submodule
+
+            ${{ env.SHORTLOG }}
+          title: "Bump fedora-bootc submodule"
+          body: |
+            Created by [GitHub workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/bump-fedora-bootc.yml) ([source](${{ github.server_url }}/${{ github.repository }}/blob/testing-devel/.github/workflows/bump-fedora-bootc.yml)).
+
+            ```
+            ${{ env.SHORTLOG }}
+            ```
+          committer: "CoreOS Bot <coreosbot@fedoraproject.org>"
+          author: "CoreOS Bot <coreosbot@fedoraproject.org>"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fedora-bootc"]
+	path = fedora-bootc
+	url = https://gitlab.com/fedora/bootc/base-images.git

--- a/manifests/bootable-rpm-ostree.yaml
+++ b/manifests/bootable-rpm-ostree.yaml
@@ -24,8 +24,6 @@ packages-s390x:
   # On Fedora, this is provided by s390utils-core. on RHEL, this is for now
   # provided by s390utils-base, but soon will be -core too.
   - /usr/sbin/zipl
-  # for Secure Execution
-  - veritysetup
 packages-x86_64:
   - grub2 grub2-efi-x64 efibootmgr shim
   - microcode_ctl

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -6,6 +6,7 @@ include:
   - kernel.yaml
   - system-configuration.yaml
   - ignition-and-ostree.yaml
+  - bootable-rpm-ostree.yaml
   - file-transfer.yaml
   - networking-tools.yaml
   - user-experience.yaml

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -22,6 +22,7 @@ conditional-include:
   - if: releasever < 42
     include:
       - system-configuration-tier-x-dupes.yaml
+      - networking-tools-tier-x-dupes.yaml
       # See https://github.com/coreos/bootupd
       - bootupd.yaml
 

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -14,6 +14,12 @@ include:
   - bootupd.yaml
   - shared-el9.yaml
   - shared-el10.yaml
+
+conditional-include:
+  # starting from f42, we inherit from tier-x
+  - if: releasever >= 42
+    include: tier-x.yaml
+
 ostree-layers:
   - overlay/05core
   - overlay/08nouveau

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -20,14 +20,7 @@ conditional-include:
   # all these are inherited from tier-x in f42+, but we carry them here to
   # enforce that there's really no coupling until f42
   - if: releasever < 42
-    include:
-      - bootable-rpm-ostree.yaml
-      - ignition-and-ostree-tier-x-dupes.yaml
-      - system-configuration-tier-x-dupes.yaml
-      - networking-tools-tier-x-dupes.yaml
-      - user-experience-tier-x-dupes.yaml
-      # See https://github.com/coreos/bootupd
-      - bootupd.yaml
+    include: tier-x-dupes.yaml
 
 ostree-layers:
   - overlay/05core

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -6,7 +6,6 @@ include:
   - kernel.yaml
   - system-configuration.yaml
   - ignition-and-ostree.yaml
-  - bootable-rpm-ostree.yaml
   - file-transfer.yaml
   - networking-tools.yaml
   - user-experience.yaml
@@ -22,6 +21,7 @@ conditional-include:
   # enforce that there's really no coupling until f42
   - if: releasever < 42
     include:
+      - bootable-rpm-ostree.yaml
       - system-configuration-tier-x-dupes.yaml
       - networking-tools-tier-x-dupes.yaml
       - user-experience-tier-x-dupes.yaml

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -23,6 +23,7 @@ conditional-include:
     include:
       - system-configuration-tier-x-dupes.yaml
       - networking-tools-tier-x-dupes.yaml
+      - user-experience-tier-x-dupes.yaml
       # See https://github.com/coreos/bootupd
       - bootupd.yaml
 

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -22,6 +22,7 @@ conditional-include:
   - if: releasever < 42
     include:
       - bootable-rpm-ostree.yaml
+      - ignition-and-ostree-tier-x-dupes.yaml
       - system-configuration-tier-x-dupes.yaml
       - networking-tools-tier-x-dupes.yaml
       - user-experience-tier-x-dupes.yaml

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -17,11 +17,13 @@ conditional-include:
   # starting from f42, we inherit from tier-x
   - if: releasever >= 42
     include: tier-x.yaml
-  # this is inherited from tier-x in f42+, but we carry it here to
+  # all these are inherited from tier-x in f42+, but we carry them here to
   # enforce that there's really no coupling until f42
   - if: releasever < 42
-    # See https://github.com/coreos/bootupd
-    include: bootupd.yaml
+    include:
+      - system-configuration-tier-x-dupes.yaml
+      # See https://github.com/coreos/bootupd
+      - bootupd.yaml
 
 ostree-layers:
   - overlay/05core

--- a/manifests/fedora-coreos-base.yaml
+++ b/manifests/fedora-coreos-base.yaml
@@ -10,8 +10,6 @@ include:
   - networking-tools.yaml
   - user-experience.yaml
   - shared-workarounds.yaml
-  # See https://github.com/coreos/bootupd
-  - bootupd.yaml
   - shared-el9.yaml
   - shared-el10.yaml
 
@@ -19,6 +17,11 @@ conditional-include:
   # starting from f42, we inherit from tier-x
   - if: releasever >= 42
     include: tier-x.yaml
+  # this is inherited from tier-x in f42+, but we carry it here to
+  # enforce that there's really no coupling until f42
+  - if: releasever < 42
+    # See https://github.com/coreos/bootupd
+    include: bootupd.yaml
 
 ostree-layers:
   - overlay/05core

--- a/manifests/fedora-coreos.yaml
+++ b/manifests/fedora-coreos.yaml
@@ -17,7 +17,10 @@ conditional-include:
   - if: prod == false
     # long-term, would be good to support specifying a nested TreeComposeConfig
     include: disable-zincati.yaml
-  - if: basearch != "s390x"
+  - if:
+    - basearch != "s390x"
+    # for 42+, it's inherited from fedora-bootc
+    - releasever < 42
     # And remove some cruft from grub2
     include: grub2-removals.yaml
   # On <41, we want to keep making sure dnf doesn't slip in somehow
@@ -25,12 +28,14 @@ conditional-include:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1687
   - if: releasever < 41
     include: exclude-dnf.yaml
-  - if: releasever >= 41
+  # for 42+, it's inherited from fedora-bootc
+  - if: releasever == 41
     include: include-dnf.yaml
   # Wifi firmwares will be dropped in F41
   - if: releasever < 41
     include: wifi-firmwares.yaml
-  - if: releasever >= 41
+  # for 42+, it's inherited from fedora-bootc
+  - if: releasever == 41
     include: composefs.yaml
   - if: releasever >= 41
     include: selinux-workaround.yaml

--- a/manifests/ignition-and-ostree-tier-x-dupes.yaml
+++ b/manifests/ignition-and-ostree-tier-x-dupes.yaml
@@ -1,0 +1,17 @@
+# This manifest can go away in Fedora 42. It duplicates tier-x.
+
+# Modern defaults we want
+boot-location: modules
+tmp-is-dir: true
+
+# Required by Ignition, and makes the system not compatible with Anaconda
+machineid-compat: false
+
+remove-from-packages:
+  # We don't want systemd-firstboot.service. It conceptually conflicts with
+  # Ignition.  We also inject runtime bits to disable it in systemd-firstboot.service.d/fcos-disable.conf
+  # to make it easier to use systemd builds from git.
+  - [systemd, /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
+  # We don't want auto-generated mount units. See also
+  # https://github.com/systemd/systemd/issues/13099
+  - [systemd-udev, /usr/lib/systemd/system-generators/systemd-gpt-auto-generator]

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -29,6 +29,10 @@ remove-from-packages:
   # https://github.com/systemd/systemd/issues/13099
   - [systemd-udev, /usr/lib/systemd/system-generators/systemd-gpt-auto-generator]
 
+packages-s390x:
+  # for Secure Execution
+  - veritysetup
+
 postprocess:
   # Undo RPM scripts enabling units; we want the presets to be canonical
   # https://github.com/projectatomic/rpm-ostree/issues/1803

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -5,27 +5,11 @@
 # One good model is to add fedora-coreos-config as a git submodule.  See:
 # https://github.com/coreos/coreos-assembler/pull/639
 
-# Modern defaults we want
-boot-location: modules
-tmp-is-dir: true
-
-# Required by Ignition, and makes the system not compatible with Anaconda
-machineid-compat: false
-
 packages:
   - ignition
   - dracut-network
   # for encryption
   - clevis clevis-luks clevis-dracut clevis-systemd
-
-remove-from-packages:
-  # We don't want systemd-firstboot.service. It conceptually conflicts with
-  # Ignition.  We also inject runtime bits to disable it in systemd-firstboot.service.d/fcos-disable.conf
-  # to make it easier to use systemd builds from git.
-  - [systemd, /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
-  # We don't want auto-generated mount units. See also
-  # https://github.com/systemd/systemd/issues/13099
-  - [systemd-udev, /usr/lib/systemd/system-generators/systemd-gpt-auto-generator]
 
 packages-s390x:
   # for Secure Execution

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -22,9 +22,7 @@ remove-from-packages:
   # We don't want systemd-firstboot.service. It conceptually conflicts with
   # Ignition.  We also inject runtime bits to disable it in systemd-firstboot.service.d/fcos-disable.conf
   # to make it easier to use systemd builds from git.
-  - [systemd, /usr/bin/systemd-firstboot,
-              /usr/lib/systemd/system/systemd-firstboot.service,
-              /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
+  - [systemd, /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service]
   # We don't want auto-generated mount units. See also
   # https://github.com/systemd/systemd/issues/13099
   - [systemd-udev, /usr/lib/systemd/system-generators/systemd-gpt-auto-generator]

--- a/manifests/ignition-and-ostree.yaml
+++ b/manifests/ignition-and-ostree.yaml
@@ -5,9 +5,6 @@
 # One good model is to add fedora-coreos-config as a git submodule.  See:
 # https://github.com/coreos/coreos-assembler/pull/639
 
-# Include rpm-ostree + kernel + bootloader
-include: bootable-rpm-ostree.yaml
-
 # Modern defaults we want
 boot-location: modules
 tmp-is-dir: true

--- a/manifests/networking-tools-tier-x-dupes.yaml
+++ b/manifests/networking-tools-tier-x-dupes.yaml
@@ -1,0 +1,8 @@
+# This manifest can go away in Fedora 42. It duplicates tier-x.
+
+packages:
+  # Standard tools for configuring network/hostname
+  - NetworkManager hostname
+  - iproute
+  # Firewall manipulation
+  - iptables

--- a/manifests/networking-tools.yaml
+++ b/manifests/networking-tools.yaml
@@ -3,17 +3,15 @@
 # generic enough to be shared downstream with RHCOS.
 
 packages:
-  # Standard tools for configuring network/hostname
-  - NetworkManager hostname
   # Interactive Networking configuration during coreos-install
   - NetworkManager-tui
   # Support for cloud quirks and dynamic config in real rootfs:
   # https://github.com/coreos/fedora-coreos-tracker/issues/320
   - NetworkManager-cloud-setup
-  # Route manipulation and QoS
-  - iproute iproute-tc
+  # Route QoS
+  - iproute-tc
   # Firewall manipulation
-  - iptables nftables
+  - nftables
   # Interactive network tools for admins
   - socat net-tools bind-utils
   # Declarative network configuration

--- a/manifests/system-configuration-tier-x-dupes.yaml
+++ b/manifests/system-configuration-tier-x-dupes.yaml
@@ -1,0 +1,14 @@
+# This manifest can go away in Fedora 42. It duplicates tier-x.
+
+packages:
+  - cryptsetup
+  - e2fsprogs
+  - lvm2
+  - xfsprogs
+  # SELinux policy
+  - selinux-policy-targeted
+  # Allow for configuring different timezones
+  - tzdata
+  # zram-generator (but not zram-generator-defaults) for F33 change
+  # https://github.com/coreos/fedora-coreos-tracker/issues/509
+  - zram-generator

--- a/manifests/system-configuration.yaml
+++ b/manifests/system-configuration.yaml
@@ -16,19 +16,13 @@ packages:
   ## cloud-utils-growpart - For growing root partition
   - cifs-utils
   - cloud-utils-growpart
-  - cryptsetup
   - device-mapper-multipath
-  - e2fsprogs
   - iscsi-initiator-utils
-  - lvm2
   - mdadm
   - sg3_utils
-  - xfsprogs
   # User configuration
   - shadow-utils
   - acl
-  # SELinux policy
-  - selinux-policy-targeted
   # There are things that write outside of the journal still (such as the
   # classic wtmp, etc.). auditd also writes outside the journal but it has its
   # own log rotation.
@@ -41,11 +35,6 @@ packages:
   - stalld
   # Ignition aware SSH key management
   - ssh-key-dir
-  # Allow for configuring different timezones
-  - tzdata
-  # zram-generator (but not zram-generator-defaults) for F33 change
-  # https://github.com/coreos/fedora-coreos-tracker/issues/509
-  - zram-generator
 
 postprocess:
   # Mask systemd-repart. Ignition is responsible for partition setup on first

--- a/manifests/tier-x-dupes.yaml
+++ b/manifests/tier-x-dupes.yaml
@@ -1,0 +1,11 @@
+# All of these manifests duplicate tier-x. It's meant to be included by streams
+# which do not yet inherit from it (like FCOS <42, and "traditional" RHCOS)
+
+include:
+  - bootable-rpm-ostree.yaml
+  - ignition-and-ostree-tier-x-dupes.yaml
+  - system-configuration-tier-x-dupes.yaml
+  - networking-tools-tier-x-dupes.yaml
+  - user-experience-tier-x-dupes.yaml
+  # See https://github.com/coreos/bootupd
+  - bootupd.yaml

--- a/manifests/tier-x.yaml
+++ b/manifests/tier-x.yaml
@@ -1,0 +1,14 @@
+# Here, we include tier-x, but override some key settings.
+
+include: ../fedora-bootc/tier-x/manifest.yaml
+
+# Required by Ignition, and makes the system not compatible with Anaconda.
+# Note this deviates from fedora-bootc and means `systemctl enable` doesn't
+# work in a container build. We'll have to resolve that issue some other way in
+# the future... For more details, see
+# https://github.com/CentOS/centos-bootc/issues/167
+machineid-compat: false
+
+# This is the historical default and what FCOS currently ships. fedora-bootc
+# uses the new `root` value, but migrating FCOS is not that simple...
+opt-usrlocal: var

--- a/manifests/user-experience-tier-x-dupes.yaml
+++ b/manifests/user-experience-tier-x-dupes.yaml
@@ -1,0 +1,26 @@
+# This manifest can go away in Fedora 42. It duplicates tier-x.
+
+# Default to `bash` in our container, the same as other containers we ship.
+# Note this changes to /sbin/init in f42 as inherited by tier-x.
+container-cmd:
+  - /usr/bin/bash
+
+packages:
+  # Basic user tools
+  - bash-completion
+  - coreutils
+  # jq - parsing/interacting with JSON data
+  - jq
+  - less
+  - sudo
+  - vim-minimal
+  # File compression/decompression
+  - tar
+  # Remote Access
+  - openssh-clients openssh-server
+  # Container tooling
+  ## crun recommends but doesn't require criu and criu-libs. We want them for
+  ## checkpoint/restore. https://github.com/coreos/fedora-coreos-tracker/issues/1370
+  - crun criu criu-libs
+  - podman
+  - skopeo

--- a/manifests/user-experience.yaml
+++ b/manifests/user-experience.yaml
@@ -2,9 +2,6 @@
 # https://github.com/openshift/os/blob/71c974b1e456292033e3ef3fe7bcfe17d1855ebc/manifest.yaml#L12
 # Only apply changes here that should apply to both FCOS and RHCOS.
 
-# Default to `bash` in our container, the same as other containers we ship.
-container-cmd:
-  - /usr/bin/bash
 
 # These packages are either widely used utilities/services or
 # are targeted for improving the general CoreOS user experience.
@@ -12,20 +9,12 @@ container-cmd:
 # RHCOS.
 packages:
   # Basic user tools
-  ## jq - parsing/interacting with JSON data
-  - bash-completion
-  - coreutils
   - file
-  - jq
-  - less
-  - sudo
-  - vim-minimal
   # File compression/decompression
   ## bsdtar - dependency of 35coreos-live dracut module
   - bsdtar
   - bzip2
   - gzip
-  - tar
   - xz
   - zstd
   # Improved MOTD experience
@@ -34,14 +23,6 @@ packages:
   # kdump support
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
   - kexec-tools
-  # Remote Access
-  - openssh-clients openssh-server
-  # Container tooling
-  ## crun recommends but doesn't require criu and criu-libs. We want them for
-  ## checkpoint/restore. https://github.com/coreos/fedora-coreos-tracker/issues/1370
-  - crun criu criu-libs
-  - podman
-  - skopeo
   - toolbox
   # passt provides user-mode networking daemons for namespaces
   - passt


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/jlebon/fedora-coreos-config/actions/workflows/bump-fedora-bootc.yml) ([source](https://github.com/jlebon/fedora-coreos-config/blob/testing-devel/.github/workflows/bump-fedora-bootc.yml)).

```
Jonathan Lebon (4):
      tier-0: explicitly list coreutils
      tier-x: explicitly list podman, skopeo
      tier-0: drop `mkdir -p /run` workaround
      tier-0: fix sed invocation
```